### PR TITLE
ENH: Multiple parameters & avoid unwanted link corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins:
 
 - __filter_links__: Existing links may be broken due to unwanted replacement. Activate this parameter to avoid the issue. Caution: This may impact performance in large environments.
 - __reference_prefix__: This prefix appended by a number will generate a link any time it is found in a page.
-- __target_url__: The URL must contain `<num>` for the reference number.
+- __target_url__: The URL must contain at least one variable from `reference_prefix` (default: `<num>`).
 
 > ⚠️ The use of prefixes without variable (like `GH-`) is deprecated and support will be dropped in an upcoming release.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Edit your `mkdocs.yml` file and add these few lines of code:
 ```yaml
 plugins:
    - argref:
+        filter_links: False  #default
         autolinks:
-            - reference_prefix: GH-
+            - reference_prefix: GH-<num>
               target_url: https://github.com/myname/myproject/issues/<num>
-            - reference_prefix: PROJ-
-              target_url: https://jiracloud.com/PROJ-<num>
+            - reference_prefix: COMPLEX-<num>-<ver>
+              target_url: https://jiracloud.com/COMPLEX-<num>?ver=<ver>
 ```
 
+- __filter_links__: Existing links may be broken due to unwanted replacement. Activate this parameter to avoid the issue. Caution: This may impact performance in large environments.
 - __reference_prefix__: This prefix appended by a number will generate a link any time it is found in a page.
 - __target_url__: The URL must contain `<num>` for the reference number.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ plugins:
 - __reference_prefix__: This prefix appended by a number will generate a link any time it is found in a page.
 - __target_url__: The URL must contain `<num>` for the reference number.
 
+> ⚠️ The use of prefixes without variable (like `GH-`) is deprecated and support will be dropped in an upcoming release.
+
 ### An example
 
 For example, you could edit the `docs/index.md` file and insert the ticket references like this:

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -150,7 +150,7 @@ class AutolinkReference(BasePlugin):
         :param kwargs: Other parameters (won't be used here)
         :return: Modified markdown
         """
-        link_filter_enabled = autolink.get("filter_links", False) is True
+        link_filter_enabled = self.config.get("filter_links", False) is True
         wrapper = AutoLinkWrapper(markdown, link_filter_enabled)
 
         with wrapper as wrapped_markdown:

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -4,7 +4,7 @@ from mkdocs.config import config_options
 
 
 class MarkdownAutoLinker:
-    original_tag = "original_text"
+    original_tag = "__ARGREF_ORIGINAL_TEXT__"
 
     def __init__(self, markdown, reference, target_url):
         self.markdown = markdown

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -64,7 +64,7 @@ class AutoLinkWrapper:
     def __init__(self, markdown, link_filter_enabled):
         self.wrapped_markdown = AutoLinkWrapper.WrappedMarkdown(markdown)
         self.link_filter_enabled = link_filter_enabled
-        self.__links = []
+        self.links = []
 
     @property
     def markdown(self):
@@ -76,17 +76,17 @@ class AutoLinkWrapper:
             if match is None:
                 break
 
-            self.__links.append(match.group(0))
+            self.links.append(match.group(0))
             self.wrapped_markdown.content = (
                 self.wrapped_markdown.content[: match.start()]
-                + self.placeholder.format(len(self.__links))
+                + self.placeholder.format(len(self.links))
                 + self.wrapped_markdown.content[match.end() :]
             )
 
     def recover_links(self):
-        while len(self.__links) > 0:
+        while len(self.links) > 0:
             self.wrapped_markdown.content = self.wrapped_markdown.content.replace(
-                self.placeholder.format(len(self.__links)), self.__links.pop()
+                self.placeholder.format(len(self.links)), self.links.pop()
             )
 
     def __enter__(self):

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -19,7 +19,9 @@ class MarkdownAutoLinker:
     def _get_reference_pattern(cls, reference):
         # ensure default <num> exists
         if "<num>" not in reference:
-            log.warning(f"the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: {reference}")
+            log.warning(
+                f"the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: {reference}"
+            )
             reference = reference + "<num>"
 
         # make all variables like <...> in reference detectable
@@ -61,7 +63,7 @@ class AutoLinkWrapper:
         @property
         def content(self):
             return self.__content
-        
+
         @content.setter
         def content(self, content):
             self.__content = content

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -132,7 +132,7 @@ class AutoLinkOption(config_options.OptionallyRequired):
             variables = re.findall(MarkdownAutoLinker.variable_pattern, autolink["reference_prefix"])
             variables.append("<num>")  # FIXME: remove in next version
             if not any(v in autolink["target_url"] for v in variables):
-                raise config_options.ValidationError("At least variable must be used in 'target_url'")
+                raise config_options.ValidationError("At least one variable must be used in 'target_url'")
 
         return values
 

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -3,17 +3,86 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
 
 
+class MarkdownAutoLinker:
+    original_tag = "original_text"
+
+    def __init__(self, markdown, reference, target_url):
+        self.markdown = markdown
+        self.reference_pattern = self._get_reference_pattern(reference)
+        self.link_replace_text = self._get_link_replace_text(target_url)
+
+    @classmethod
+    def _get_reference_pattern(cls, reference):
+        # ensure default <num> exists
+        if "<num>" not in reference:
+            reference = reference + "<num>"
+
+        # make all variables like <...> in reference detectable
+        reference_pattern = re.sub(re.compile(r"<(\S+?)>"), r"(?P<\1>[-\\w]+)", reference)
+
+        # ensure original text is available
+        return re.compile(
+            rf"(?<![#\[/])(?P<{cls.original_tag}>" + reference_pattern + r")",
+            re.IGNORECASE,
+        )
+
+    @classmethod
+    def _get_link_replace_text(cls, target_url):
+        # define template for markdown link
+        template_for_linked_reference = rf"[<{cls.original_tag}>](" + target_url + r")"
+
+        # make all variables like <...> in linked reference replacable
+        return re.sub(r"\<(\S+?)\>", r"\\g<\1>", template_for_linked_reference)
+
+    def markdown_has_reference(self):
+        return self.reference_pattern.match(self.markdown) is not None
+
+    def replace_all_references(self):
+        self.markdown = re.sub(self.reference_pattern, self.link_replace_text, self.markdown)
+
+
+class LinkFilter:
+    link_pattern = re.compile(r"\[[!\]]+\]\([!\)]*\)")
+    placeholder = "___AUTOLINK_PLACEHOLDER_{i}___"
+
+    def __init__(self, autolinker):
+        self.autolinker = autolinker
+        self.__links = []
+
+    def filter_links(self):
+        while True:
+            match = self.link_pattern.match(self.autolinker.markdown)
+            if match is None:
+                break
+
+            self.__links.append(match.string)
+            self.__markdown = self.__markdown[:match.start()] + self.placeholder.format(i=len(self.__links)) + self.autolinker.markdown[match.end():]
+
+            i += 1
+
+    def recover_links(self):
+        while len(self.__links) > 0:
+            self.__markdown.replace(self.placeholder.format(i==len(self.__links)), self.__links.pop())
+
+    def __enter__(self):
+        self.filter_links()
+        return self.autolinker
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.recover_links()
+
+
 def replace_autolink_references(markdown, ref_prefix, target_url):
-    if "<num>" not in ref_prefix:
-        ref_prefix = ref_prefix + "<num>"
-    find_regex = re.compile(
-        r"(?<![#\[/])" + ref_prefix.replace(r"<num>", r"(?P<num>[-\w]+)"),
-        re.IGNORECASE,
-    )
-    linked_ref = rf"[{ref_prefix}](" + target_url + r")"
-    replace_text = linked_ref.replace(r"<num>", r"\g<num>")
-    markdown = re.sub(find_regex, replace_text, markdown)
-    return markdown
+    autolinker = MarkdownAutoLinker(markdown, ref_prefix, target_url)
+    filter = LinkFilter(autolinker)
+
+    if not autolinker.markdown_has_reference():
+        return autolinker.markdown
+
+    with filter as linker:
+        linker.replace_all_references()
+
+    return autolinker.markdown
 
 
 class AutoLinkOption(config_options.OptionallyRequired):

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -1,6 +1,10 @@
+import logging
 import re
 from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
+
+
+log = logging.getLogger("mkdocs.plugins.argref")
 
 
 class MarkdownAutoLinker:
@@ -15,6 +19,7 @@ class MarkdownAutoLinker:
     def _get_reference_pattern(cls, reference):
         # ensure default <num> exists
         if "<num>" not in reference:
+            log.warning(f"the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: {reference}")
             reference = reference + "<num>"
 
         # make all variables like <...> in reference detectable

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -99,6 +99,14 @@ ignore_ref_links = [
 ]
 
 
+def test_deprecated_warning(caplog):
+    test_input = "GH-123"
+    ref_prefix = "GH-"
+    target_url = "http://gh/<num>"
+    autolink(test_input, ref_prefix, target_url)
+    assert "the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: GH-" in caplog.text
+
+
 def test_wrapper_with_enabled_link_filter():
     test_input = "[123](abc) [456](def) [789](ghi)"
     wrapper = AutoLinkWrapper(test_input, True)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -30,6 +30,15 @@ simple_replace = [
     ),
 ]
 
+complex_replace = [
+    (
+        "<some>-TAG-<num>-<ver>",
+        "http://foo.bar/but?<some>=<num>&ver=<ver>",
+        "file-TAG-123-XYZ",
+        "[TAG-123-XYZ](http://foo.bar/file?num=123&ver=XYZ)",
+    ),
+]
+
 ignore_already_linked = [
     (
         "TAG-<num>",
@@ -42,6 +51,21 @@ ignore_already_linked = [
         "http://gh/TAG-<num>",
         "[TAG-789](http://gh/TAG-789)",
         "[TAG-789](http://gh/TAG-789)",
+    ),
+    (
+        "TAG-<num>",
+        "http://gh/TAG-<num>",
+        "[see TAG-789](http://gh/TAG-789)",
+        "[see TAG-789](http://gh/TAG-789)",
+    ),
+]
+
+ignore_url_paths = [
+    (
+        "TAG-<num>",
+        "http://gh/<num>",
+        "[Go Here](http://gh/TAG-789) [Go There](http://gh/TAG-123)",
+        "[Go Here](http://gh/TAG-789) [Go There](http://gh/TAG-123)",
     ),
 ]
 
@@ -61,7 +85,7 @@ ignore_ref_links = [
 
 @pytest.mark.parametrize(
     "ref_prefix, target_url, test_input, expected",
-    simple_replace + ignore_already_linked + ignore_ref_links,
+    simple_replace + complex_replace + ignore_already_linked + ignore_url_paths + ignore_ref_links,
 )
 def test_parser(ref_prefix, target_url, test_input, expected):
     assert autolink(test_input, ref_prefix, target_url) == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -104,14 +104,20 @@ def test_deprecated_warning(caplog):
     ref_prefix = "GH-"
     target_url = "http://gh/<num>"
     autolink(test_input, ref_prefix, target_url)
-    assert "the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: GH-" in caplog.text
+    assert (
+        "the use of prefixes without variable is deprecated and support will be dropped in an upcoming release: GH-"
+        in caplog.text
+    )
 
 
 def test_wrapper_with_enabled_link_filter():
     test_input = "[123](abc) [456](def) [789](ghi)"
     wrapper = AutoLinkWrapper(test_input, True)
     with wrapper as wrapped_markdown:
-        assert wrapped_markdown.content == "___AUTOLINK_PLACEHOLDER_1___ ___AUTOLINK_PLACEHOLDER_2___ ___AUTOLINK_PLACEHOLDER_3___"
+        assert (
+            wrapped_markdown.content
+            == "___AUTOLINK_PLACEHOLDER_1___ ___AUTOLINK_PLACEHOLDER_2___ ___AUTOLINK_PLACEHOLDER_3___"
+        )
 
     assert wrapped_markdown.content == test_input
 
@@ -125,16 +131,15 @@ def test_wrapper_with_disabled_link_filter():
 
 @pytest.mark.parametrize(
     "ref_prefix, target_url, test_input, expected",
-    simple_replace
-    + complex_replace
-    + ignore_already_linked
-    + ignore_ref_links,
+    simple_replace + complex_replace + ignore_already_linked + ignore_ref_links,
 )
 @pytest.mark.parametrize("filter_links", (True, False))
 def test_parser(ref_prefix, target_url, test_input, expected, filter_links):
     wrapper = AutoLinkWrapper(test_input, filter_links)
     with wrapper as wrapped_mackdown:
-        wrapped_mackdown.content = autolink(wrapped_mackdown.content, ref_prefix, target_url)
+        wrapped_mackdown.content = autolink(
+            wrapped_mackdown.content, ref_prefix, target_url
+        )
     assert wrapper.markdown == expected
 
 
@@ -145,7 +150,9 @@ def test_parser(ref_prefix, target_url, test_input, expected, filter_links):
 def test_activated_link_filter(ref_prefix, target_url, test_input, expected):
     wrapper = AutoLinkWrapper(test_input, True)
     with wrapper as wrapped_mackdown:
-        wrapped_mackdown.content = autolink(wrapped_mackdown.content, ref_prefix, target_url)
+        wrapped_mackdown.content = autolink(
+            wrapped_mackdown.content, ref_prefix, target_url
+        )
     assert wrapper.markdown == expected
 
 
@@ -156,7 +163,9 @@ def test_activated_link_filter(ref_prefix, target_url, test_input, expected):
 def test_deactivated_link_filter(ref_prefix, target_url, test_input, expected):
     wrapper = AutoLinkWrapper(test_input, False)
     with wrapper as wrapped_mackdown:
-        wrapped_mackdown.content = autolink(wrapped_mackdown.content, ref_prefix, target_url)
+        wrapped_mackdown.content = autolink(
+            wrapped_mackdown.content, ref_prefix, target_url
+        )
     assert wrapper.markdown == expected
 
 
@@ -168,7 +177,9 @@ def test_with_attr_list(filter_links):
     target_url = "http://gh/<num>"
     wrapper = AutoLinkWrapper(text, False)
     with wrapper as wrapped_mackdown:
-        wrapped_mackdown.content = autolink(wrapped_mackdown.content, ref_prefix, target_url)
+        wrapped_mackdown.content = autolink(
+            wrapped_mackdown.content, ref_prefix, target_url
+        )
     assert wrapper.markdown == text
 
 
@@ -180,5 +191,7 @@ def test_multi_replace(filter_links):
     expected = "[TAG-1](http://gh/1) [TAG-1](http://gh/1) [TAG-1](http://gh/1)"
     wrapper = AutoLinkWrapper(markdown, False)
     with wrapper as wrapped_mackdown:
-        wrapped_mackdown.content = autolink(wrapped_mackdown.content, ref_prefix, target_url)
+        wrapped_mackdown.content = autolink(
+            wrapped_mackdown.content, ref_prefix, target_url
+        )
     assert wrapper.markdown == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,7 +121,7 @@ def test_validation_of_missing_variable_in_target_url():
     ]
     with pytest.raises(config_options.ValidationError) as exc_info:
         AutoLinkOption().run_validation(values)
-    assert exc_info.value.args[0] == "At least variable must be used in 'target_url'"
+    assert exc_info.value.args[0] == "At least one variable must be used in 'target_url'"
 
 
 def test_validation_of_at_least_one_variable_in_prefix_found_in_target_url():


### PR DESCRIPTION
I have created this PR to fulfil the following user stories:

* I as a user want to use more complex references to create links with extended information (e.g. version).
* I as a user want to avoid broken links when references are found in an existing markdown link.
* I as a user want to deactivate filtering links during replace when performance is too low.

Happy to extend code, tests or answer your questions.