### PR TITLE
Bug fix for filtering links

### DIFF
--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -146,8 +146,8 @@ class AutolinkReference(BasePlugin):
         link_filter_enabled = self.config.get("filter_links", False) is True
         wrapper = AutoLinkWrapper(markdown, link_filter_enabled)
 
-        with wrapper as wrapped_markdown:
-            for autolink in self.config["autolinks"]:
+        for autolink in self.config["autolinks"]:
+            with wrapper as wrapped_markdown:
                 wrapped_markdown.content = replace_autolink_references(
                     wrapped_markdown.content,
                     autolink["reference_prefix"],

--- a/src/argref/main.py
+++ b/src/argref/main.py
@@ -128,7 +128,10 @@ class AutoLinkOption(config_options.OptionallyRequired):
 
 
 class AutolinkReference(BasePlugin):
-    config_scheme = (("autolinks", AutoLinkOption(required=True)),)
+    config_scheme = (
+        ("autolinks", AutoLinkOption(required=True)),
+        ("filter_links", config_options.Type(bool, default=False)),
+    )
 
     def on_page_markdown(self, markdown, **kwargs):
         """


### PR DESCRIPTION
Unfortunately, two issues arose in our productive environment:

1. configuration was prohibited (see 9341212)
2. optimization of filter being applied only once broke autolink rules for similar patterns (see 1e10170)

Sorry for the inconvenience. I'm unable to test sample code in our productive environment.